### PR TITLE
Conduct light cleanup and spellchecking on quest text

### DIFF
--- a/config/ftbquests/normal/chapters/0722378b/4146d297.snbt
+++ b/config/ftbquests/normal/chapters/0722378b/4146d297.snbt
@@ -2,7 +2,7 @@
 	x: 8.0d,
 	y: 4.0d,
 	text: [
-		"At the cost of some grid powewr and some RF, this machine can harness the power of enchanting to create some pretty cool things.",
+		"At the cost of some grid power and some RF, this machine can harness the power of enchanting to create some pretty cool things.",
 		"Just like an enchanting table, this requires some external boost (from bookshelves, magical wood, etc.)"
 	],
 	dependencies: [

--- a/config/ftbquests/normal/chapters/13b80431/347fb19a.snbt
+++ b/config/ftbquests/normal/chapters/13b80431/347fb19a.snbt
@@ -6,7 +6,7 @@
 	description: "Light up a rectangle of obsidian",
 	text: [
 		"The first layer of caves located underneath Terra's surface is called the Nether by its inhabitants.",
-		"It is full of liquid magma, yet the strange properties of its rocks and vegetation, which mostly feeds on sulfus and other inorganic compounds, make these caves breathable, and not particularly hot."
+		"It is full of liquid magma, yet the strange properties of its rocks and vegetation, which mostly feeds on sulfur and other inorganic compounds, make these caves breathable, and not particularly hot."
 	],
 	dependencies: [
 		"5d48a82a"

--- a/config/ftbquests/normal/chapters/13b80431/5d48a82a.snbt
+++ b/config/ftbquests/normal/chapters/13b80431/5d48a82a.snbt
@@ -6,8 +6,8 @@
 	text: [
 		"Terra is a really weird planet, and for more that one reason.",
 		"Due to its size, it should definitely be a gas giant, yet, for some reason, it is solid, and it's atmosphere is mostly made out of light gases, making it breathable.",
-		"Although it has a moon, Luna, orbiting it at a fairly large distance, Terra is also surrounded by a moltitude of island-like asteroids.",
-		"These asteroids, due to their proximity, lie within the planet's atmosphere, and act as sky islands where gravity is pretty much mantained.",
+		"Although it has a moon, Luna, orbiting it at a fairly large distance, Terra is also surrounded by a multitude of island-like asteroids.",
+		"These asteroids, due to their proximity, lie within the planet's atmosphere, and act as sky islands where gravity is pretty much maintained.",
 		"In addition to this, many regions of the planet's interior are hollow, in the form of very large caves situated at about the same distance from the core."
 	],
 	dependencies: [

--- a/config/ftbquests/normal/chapters/13b80431/74184b9e.snbt
+++ b/config/ftbquests/normal/chapters/13b80431/74184b9e.snbt
@@ -5,7 +5,7 @@
 	y: 8.0d,
 	description: "Place 12 arcana portals in a horizontal square frame (place while standing in center block)",
 	text: [
-		"Not only magic is real, but so are deities. The Dungeon of arcane, as hard it is to believe, is a separate plane of existance, existing in higher dimensions, similar to the world of Alfheim, origin of many of the powers of natural magic.",
+		"Not only magic is real, but so are deities. The Dungeon of arcane, as hard it is to believe, is a separate plane of existence, existing in higher dimensions, similar to the world of Alfheim, origin of many of the powers of natural magic.",
 		"This (literally) infinite fortress is the realm of two masters of the natural arts, who have used their great power to infinitely extend a three-dimensional space into another higher dimension.",
 		"Similarly, the power of these 'gods' has allowed for the infinite repetition of their being, meaning that, in this plane, they exist everywhere and nowhere."
 	],

--- a/config/ftbquests/normal/chapters/13b80431/a6a99509.snbt
+++ b/config/ftbquests/normal/chapters/13b80431/a6a99509.snbt
@@ -4,8 +4,8 @@
 	x: -1.0d,
 	y: 5.0d,
 	text: [
-		"The betweenlands, not unlike the Erebus caves, do not apper at exist within the three dimensions of space senses can feel.",
-		"Because of 'slices' that can be sometimes seen. It is evident that this place is located on terra, but it exists in higher dimensions, making it impossible to perceive for a three-dimensional being, unless the portal to this cursed swamp is used."
+		"The betweenlands, not unlike the Erebus caves, do not appear at exist within the three dimensions of space senses can feel.",
+		"Because of 'slices' that can be sometimes seen. It is evident that this place is located on Terra, but it exists in higher dimensions, making it impossible to perceive for a three-dimensional being, unless the portal to this cursed swamp is used."
 	],
 	dependencies: [
 		"446239db"

--- a/config/ftbquests/normal/chapters/37c824bb/23ff95f6.snbt
+++ b/config/ftbquests/normal/chapters/37c824bb/23ff95f6.snbt
@@ -5,7 +5,7 @@
 	description: "Used to craft machines from actually additions (see manufacturing and fabrication)",
 	text: [
 		"Wow, if only humanity knew of this!",
-		"It seems like there are other energy storage optionsthat are way better than batteries.",
+		"It seems like there are other energy storage options that are way better than batteries.",
 		"Not only I can store energy in other ways, but I can easily transform between different types of energy, including lasers..."
 	],
 	dependencies: [

--- a/config/ftbquests/normal/chapters/37c824bb/28204df5.snbt
+++ b/config/ftbquests/normal/chapters/37c824bb/28204df5.snbt
@@ -1,7 +1,7 @@
 {
 	x: 32.0d,
 	y: -7.5d,
-	description: "Lord vatticus will trade the wizard book, right click it on the Phoenix Altar",
+	description: "Lord Vatticus will trade the wizard book, right click it on the Phoenix Altar",
 	dependencies: [
 		"dd400df7"
 	],

--- a/config/ftbquests/normal/chapters/37c824bb/2b6345ee.snbt
+++ b/config/ftbquests/normal/chapters/37c824bb/2b6345ee.snbt
@@ -6,7 +6,7 @@
 		"No matter the scale of the war, it seems like everyone has the same motifs as on Earth.",
 		"Just like a certain western power in the early 2000s, it is all about resource control.",
 		"Many of the planets and planes under the control of the Shyre empire are composed of materials with interesting properties.",
-		"The affinity of these soils to the caotic, entropic effects I encountered on the upper sky of Terra is extremely interesting!",
+		"The affinity of these soils to the chaotic, entropic effects I encountered on the upper sky of Terra is extremely interesting!",
 		"...and powerful, very powerful!"
 	],
 	dependencies: [

--- a/config/ftbquests/normal/chapters/37c824bb/336f950f.snbt
+++ b/config/ftbquests/normal/chapters/37c824bb/336f950f.snbt
@@ -1,7 +1,7 @@
 {
 	x: 23.0d,
 	y: -9.0d,
-	description: "Use the unfathomatoble breaker to open the unfathomatoble gate in the deep dark.",
+	description: "Use the unfathomable breaker to open the unfathomable gate in the deep dark.",
 	dependencies: [
 		"7b03e812"
 	],

--- a/config/ftbquests/normal/chapters/37c824bb/35045c8c.snbt
+++ b/config/ftbquests/normal/chapters/37c824bb/35045c8c.snbt
@@ -2,7 +2,7 @@
 	title: "Abyss Falls",
 	x: 45.5d,
 	y: -4.5d,
-	description: "Use a staring eye on illusion altar to summon elusive - To summon the shadowlord usee a book of shadows on a shadow altar",
+	description: "Use a staring eye on illusion altar to summon elusive - To summon the shadowlord use a book of shadows on a shadow altar",
 	text: [
 		"Unexpectedly, I stumbled upon a very interesting piece of stage 5 politics...",
 		"The Horde and the Empire, as I've clearly seen on furatto, don't really have a problem at fighting each other at a larger scale.",

--- a/config/ftbquests/normal/chapters/37c824bb/6640f93d.snbt
+++ b/config/ftbquests/normal/chapters/37c824bb/6640f93d.snbt
@@ -4,7 +4,7 @@
 	y: -3.0d,
 	description: "Use the guardian's eye on graw altar",
 	text: [
-		"The master of Lelyetia has been taken down, and the weird feeling I felt when I first eneterd is partially gone.",
+		"The master of Lelyetia has been taken down, and the weird feeling I felt when I first entered is partially gone.",
 		"This land still holds some secrets, and I am set on figuring out what's going on!"
 	],
 	dependencies: [

--- a/config/ftbquests/normal/chapters/37c824bb/74d9cee9.snbt
+++ b/config/ftbquests/normal/chapters/37c824bb/74d9cee9.snbt
@@ -4,7 +4,7 @@
 	y: 3.0d,
 	description: "Used to craft machines from forestry and gendustry (see manufacturing and fabrication)",
 	text: [
-		"For some reason, the local vegetation seems to have an affinity for bronze, so I deviced a machine casing that should work very well at handling vegetation and farming."
+		"For some reason, the local vegetation seems to have an affinity for bronze, so I devised a machine casing that should work very well at handling vegetation and farming."
 	],
 	dependencies: [
 		"8b210b51"

--- a/config/ftbquests/normal/chapters/37c824bb/79161ace.snbt
+++ b/config/ftbquests/normal/chapters/37c824bb/79161ace.snbt
@@ -2,7 +2,7 @@
 	title: "Alien technology is cool!",
 	x: 15.5d,
 	y: 1.5d,
-	description: "Used to craft machines from enderIO (see manufacturing and fabrication)",
+	description: "Used to craft machines from EnderIO (see manufacturing and fabrication)",
 	text: [
 		"It seems like my unwanted connection with death has some other uses besides immortality.",
 		"This death energy can be used to make machines!"

--- a/config/ftbquests/normal/chapters/37c824bb/7a779752.snbt
+++ b/config/ftbquests/normal/chapters/37c824bb/7a779752.snbt
@@ -2,7 +2,7 @@
 	title: "Am I the Highlander?",
 	x: -1.0d,
 	y: -4.5d,
-	description: "Right click a grave to give your key the abilty to teleport you.",
+	description: "Right click a grave to give your key the ability to teleport you.",
 	text: [
 		"It seems like I can gain some control over this 'undeath' power. ",
 		"By infusing stone with this weird powder, I can fast travel back to my point of 'death'."

--- a/config/ftbquests/normal/chapters/37c824bb/7d6a7467.snbt
+++ b/config/ftbquests/normal/chapters/37c824bb/7d6a7467.snbt
@@ -1,11 +1,11 @@
 {
 	x: 30.5d,
 	y: -12.0d,
-	description: "Escape the dungeon of arcana using the gaia tesseract",
+	description: "Escape the dungeon of arcana using the Gaia tesseract",
 	text: [
 		"The fact that the names of Norse Mythology appear in botanical magic is, well, very interesting.",
 		"Did our ancestors know something we have forgotten?",
-		"I do not know why or how, but the power withn mana compelled me to the Dungeon of Arcana.",
+		"I do not know why or how, but the power within mana compelled me to the Dungeon of Arcana.",
 		"Knowing this, I started researching Norse legends for clues.",
 		"One word, somehow, resonated with me from these old texts...a revelation came to me",
 		"Asgard, once the realm of gods, has been defeated by the Twilight Horde, and turned into Arcana.",

--- a/config/ftbquests/normal/chapters/37c824bb/88fe69fd.snbt
+++ b/config/ftbquests/normal/chapters/37c824bb/88fe69fd.snbt
@@ -9,7 +9,7 @@
 		"After extensive observation on mythic remains, and thanks to the branches of magic I am now adept to, I was able to 'understand' mythic powers.",
 		"Well 'understanding' is a strong word, but it 'makes sense'.",
 		"The power of 'gods', beings that are able to subject reality itself to their control, seems to be 'guiding' the horde and the empire.",
-		"This power has no bounds, I cannot imagine what beings able to weild it may look like."
+		"This power has no bounds, I cannot imagine what beings able to wield it may look like."
 	],
 	dependencies: [
 		"829fbc56"

--- a/config/ftbquests/normal/chapters/37c824bb/9970ceca.snbt
+++ b/config/ftbquests/normal/chapters/37c824bb/9970ceca.snbt
@@ -7,7 +7,7 @@
 		"This is quite interesting, the thaumic energy held in dragon remains hold some sort of code, coordinates...",
 		"...to a location just outside this solar system, there's no doubt about it!",
 		"It is clear that these coordinates are placed intentionally.",
-		"By travelling there I'll kill two birds with one stone! I can continue my research on gravity, and I can investigate what's going on at those coordinates."
+		"By traveling there I'll kill two birds with one stone! I can continue my research on gravity, and I can investigate what's going on at those coordinates."
 	],
 	dependencies: [
 		"0bdb8ab8"

--- a/config/ftbquests/normal/chapters/37c824bb/a3c15cd6.snbt
+++ b/config/ftbquests/normal/chapters/37c824bb/a3c15cd6.snbt
@@ -1,5 +1,5 @@
 {
-	title: "Tools of the Master Worshipper",
+	title: "Tools of the Master Worshiper",
 	x: 17.0d,
 	y: -7.5d,
 	dependencies: [

--- a/config/ftbquests/normal/chapters/37c824bb/ab2c32d7.snbt
+++ b/config/ftbquests/normal/chapters/37c824bb/ab2c32d7.snbt
@@ -5,7 +5,7 @@
 	description: "Time to check out the book of creation tab.",
 	text: [
 		"It seems like this universal war for resources is also taking place underground.",
-		"The NETHER region of terra posesses pure mana in the form of a metal.",
+		"The NETHER region of Terra possesses pure mana in the form of a metal.",
 		"Mana appears to be a pivotal material to enable more powerful means of magic, which is why it is so closely guarded."
 	],
 	dependencies: [

--- a/config/ftbquests/normal/chapters/37c824bb/cab6d502.snbt
+++ b/config/ftbquests/normal/chapters/37c824bb/cab6d502.snbt
@@ -3,7 +3,7 @@
 	x: 23.0d,
 	y: -4.5d,
 	text: [
-		"This is very nice, obsidian and the bedrock found on Terra allow for a material that allows for loseless energy transfer in the form of waves that can travel through very long distances."
+		"This is very nice, obsidian and the bedrock found on Terra allow for a material that allows for lossless energy transfer in the form of waves that can travel through very long distances."
 	],
 	dependencies: [
 		"d4a82bd8"

--- a/config/ftbquests/normal/chapters/37c824bb/d99d33bc.snbt
+++ b/config/ftbquests/normal/chapters/37c824bb/d99d33bc.snbt
@@ -1,7 +1,7 @@
 {
 	x: 32.0d,
 	y: -9.0d,
-	description: "Lord vatticus will trade the wizard book, right click it on the Dramix Altar",
+	description: "Lord Vatticus will trade the wizard book, right click it on the Dramix Altar",
 	dependencies: [
 		"dd400df7"
 	],

--- a/config/ftbquests/normal/chapters/37c824bb/f2f2e16d.snbt
+++ b/config/ftbquests/normal/chapters/37c824bb/f2f2e16d.snbt
@@ -5,7 +5,7 @@
 	description: "Tyrosaur is summoned with a bone horn - Right click the army block in the skeletar arena to summon the skeletal horde",
 	text: [
 		"Screw you dinos! and skeletons!",
-		"The leaders of precasia are interesting. They are beings that clearly posess recursion, and they are worshipped as deities...",
+		"The leaders of precasia are interesting. They are beings that clearly possess recursion, and they are worshiped as deities...",
 		"I may be connecting too many dots here, but is it possible that the characters of legends were simply knowledgeable about recursion?"
 	],
 	dependencies: [

--- a/config/ftbquests/normal/chapters/b1f75358/01c68c36.snbt
+++ b/config/ftbquests/normal/chapters/b1f75358/01c68c36.snbt
@@ -2,7 +2,7 @@
 	x: 1.5d,
 	y: -1.0d,
 	text: [
-		"Once again, I have recieved new Isotopes. Time to experiment for some new fuel"
+		"Once again, I have received new Isotopes. Time to experiment for some new fuel"
 	],
 	dependencies: [
 		"1ad8e351"

--- a/config/ftbquests/normal/chapters/b1f75358/1ad8e351.snbt
+++ b/config/ftbquests/normal/chapters/b1f75358/1ad8e351.snbt
@@ -2,7 +2,7 @@
 	x: 0.0d,
 	y: -1.0d,
 	text: [
-		"Well it seemed to last a little bit, and produce me more power. Unforunately it seems I'm back to the rabbit hole, trying to salvage what's left of this fuel."
+		"Well it seemed to last a little bit, and produce me more power. Unfortunately it seems I'm back to the rabbit hole, trying to salvage what's left of this fuel."
 	],
 	dependencies: [
 		"7e8c82cd"

--- a/config/ftbquests/normal/chapters/b1f75358/22f0217d.snbt
+++ b/config/ftbquests/normal/chapters/b1f75358/22f0217d.snbt
@@ -2,7 +2,7 @@
 	x: -1.5d,
 	y: -8.5d,
 	text: [
-		"Similar the using Uranium in the Isotope Seperator, if I use thorium I get another new fuel source, It seems to have different properties but will still explode if over heated too much."
+		"Similar the using Uranium in the Isotope Separator, if I use thorium I get another new fuel source, It seems to have different properties but will still explode if over heated too much."
 	],
 	dependencies: [
 		"4739218e"

--- a/config/ftbquests/normal/chapters/b1f75358/b84a4807.snbt
+++ b/config/ftbquests/normal/chapters/b1f75358/b84a4807.snbt
@@ -3,7 +3,7 @@
 	x: 3.0d,
 	y: -4.0d,
 	text: [
-		"It seems I can melt down this Depleted fuel, and use it with other fluids i've encountered to create some sort of Unidentified Material? Must Investigate Further."
+		"It seems I can melt down this Depleted fuel, and use it with other fluids I've encountered to create some sort of Unidentified Material? Must Investigate Further."
 	],
 	dependencies: [
 		"d6c40044"


### PR DESCRIPTION
![Typo Correction](https://github.com/user-attachments/assets/024fe893-f5da-41b6-9c58-926f5e764cff)

Hail friend!

I wrote a [dirty, FITLHY, ruby script](https://gist.github.com/mathisto/e8260e8cfa1cfc834ec0fbff20cc9b14) to run through the `ftbquests` folder and run `aspell` against the `title`, `description`, and `text` fields. I curated the results manually, iteratively building up a [personal word exclusion list](https://gist.github.com/mathisto/17ee985d5e1b9b1b923f211b04f2c266), a meatball craft vernacular if you will.

- In some cases I tried to update proper nouns with capitalization
- When in doubt, I grepped your codebase for existing conventions and followed them

I hope this helps. Thanks again for all you incredible hard work.

