### PR TITLE
Fix a few frequently reported crashes

### DIFF
--- a/config/ZenUtils.cfg
+++ b/config/ZenUtils.cfg
@@ -1,0 +1,7 @@
+# Configuration file
+
+general {
+    B:enableMixin=true
+}
+
+

--- a/scripts/mixin/deep_mob_evolution.zs
+++ b/scripts/mixin/deep_mob_evolution.zs
@@ -1,0 +1,29 @@
+#loader mixin
+
+import native.net.minecraftforge.event.entity.living.LivingDeathEvent;
+
+import mixin.CallbackInfo;
+import native.mustapelto.deepmoblearning.common.events.EntityDeathEventHandler;
+
+/*
+Fix random crashes related to modifying UUID blacklist concurrently.
+
+Here until floppaxd/DeepMobEvolution#65 is merged.
+Created by ChaosStrikez for Deep Mob Evolution 1.2.2.
+*/
+#mixin Mixin
+#{targets: "mustapelto.deepmoblearning.common.events.EntityDeathEventHandler"}
+zenClass MixinEntityDeathEventHandler {
+  #mixin Static
+  #mixin Inject
+  #{
+  #  method: "entityDeath",
+  #  at: {value: "HEAD"},
+  #  cancellable: true
+  #}
+  function mbc_checkSide(event as LivingDeathEvent, ci as CallbackInfo) as void {
+    if (event.getEntityLiving().world.isRemote) {
+      ci.cancel();
+    }
+  }
+}

--- a/scripts/mixin/thaumic_additions.zs
+++ b/scripts/mixin/thaumic_additions.zs
@@ -1,0 +1,28 @@
+#loader mixin
+
+import native.net.minecraft.item.Item;
+import native.net.minecraft.item.ItemStack;
+
+import native.org.zeith.thaumicadditions.events.LivingEventsTAR;
+
+/*
+Fix Mithminite Hood trying to mend unrepairable items.
+
+Specifically fixes issue where it would downgrade CoFH Fluxbores.
+Created by ChaosStrikez for Thaumic Additions 12.7.9.
+*/
+#mixin Mixin
+#{targets: "org.zeith.thaumicadditions.events.LivingEventsTAR"}
+zenClass MixinLivingEventsTAR {
+  #mixin Redirect
+  #{
+  #  method: "pickupXP",
+  #  at: {
+  #    value: "INVOKE",
+  #    target: "Lnet/minecraft/item/Item;isDamaged(Lnet/minecraft/item/ItemStack;)Z"
+  #  }
+  #}
+  function mbc_checkRepairable(instance as Item, stack as ItemStack) as bool {
+    return instance.isRepairable() && !stack.getHasSubtypes() && stack.isItemDamaged();
+  }
+}


### PR DESCRIPTION
Requires updating ZenUtils (>1.20.0) for basic mixin functionality. These are a bit more niche interactions so I think it's fine here instead of UniversalTweaks for now.
- Fix mithminite hood downgrading fluxbores because of incorrect mending logic. Context: https://discord.com/channels/895732612537122836/895732613090779189/1285375037892726814
- Fix random DME crashes on entity deaths. Same fix as floppaxd/DeepMobEvolution#36, so if that ever gets merged/published, `mixin/deep_mob_evolution.zs` can be removed.