### PR TITLE
[bugfix] Re-add RFTools storage tablet + storage module recipes

### DIFF
--- a/scripts/RFToolsGating.zs
+++ b/scripts/RFToolsGating.zs
@@ -1,4 +1,5 @@
 import crafttweaker.item.IIngredient;
+import crafttweaker.recipes.IRecipeFunction;
 
 recipes.removeShaped(<rftools:builder>);
 
@@ -211,19 +212,22 @@ recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module
     return out.withTag(ins.module.tag).withDamage(0).updateTag({
         childDamage: ins.module.damage
     });
-});
+} as IRecipeFunction, null);
+
 recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module_tablet:0>, <rftools:storage_module:2>.marked("module")] as IIngredient[], function(out, ins, cInfo) {
     return out.withTag(ins.module.tag).withDamage(0).updateTag({
         childDamage: ins.module.damage
     });
-});
-recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module_tablet:0>, <rftools:storage_module:6>.marked("module")]as IIngredient[], function(out, ins, cInfo) {
+} as IRecipeFunction, null);
+
+recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module_tablet:0>, <rftools:storage_module:6>.marked("module")] as IIngredient[], function(out, ins, cInfo) {
     return out.withTag(ins.module.tag).withDamage(0).updateTag({
         childDamage: ins.module.damage
     });
-});
-recipes.addShapeless(<rftools:storage_module_tablet:2>, [<rftools:storage_module_tablet:0>, <rftools:storage_control_module>.marked("module")]as IIngredient[], function(out, ins, cInfo) {
+} as IRecipeFunction, null);
+
+recipes.addShapeless(<rftools:storage_module_tablet:2>, [<rftools:storage_module_tablet:0>, <rftools:storage_control_module>.marked("module")] as IIngredient[], function(out, ins, cInfo) {
     return out.withTag(ins.module.tag).withDamage(0).updateTag({
         childDamage: 666
     });
-});
+} as IRecipeFunction, null);

--- a/scripts/RFToolsGating.zs
+++ b/scripts/RFToolsGating.zs
@@ -196,12 +196,16 @@ recipes.addShaped(<rftools:machine_frame>*3,
 [<ore:ingotYellorium>, null, <ore:ingotYellorium>],
 [<ore:ingotAlubrass>, <ore:ingotManasteel>, <ore:ingotAlubrass>]]);
 
-
 recipes.removeShaped(<rftools:storage_module_tablet>);
 
-mods.extendedcrafting.TableCrafting.addShaped(<rftools:storage_module_tablet>, 
-[[<projecte:fuel_block:2>, <projecte:fuel_block:2>, null, <projecte:fuel_block:2>, <projecte:fuel_block:2>], 
-[<projecte:fuel_block:2>, <contenttweaker:nebulous_soul>, <appliedenergistics2:fluix_block>, <contenttweaker:nebulous_soul>, <projecte:fuel_block:2>], 
-[null, <appliedenergistics2:fluix_block>, <projecte:alchemical_chest>, <appliedenergistics2:fluix_block>, null], 
-[<projecte:fuel_block:2>, <contenttweaker:nebulous_soul>, <appliedenergistics2:fluix_block>, <contenttweaker:nebulous_soul>, <projecte:fuel_block:2>], 
-[<projecte:fuel_block:2>, <projecte:fuel_block:2>, null, <projecte:fuel_block:2>, <projecte:fuel_block:2>]]);  
+mods.extendedcrafting.TableCrafting.addShaped(<rftools:storage_module_tablet>,
+[[<projecte:fuel_block:2>, <projecte:fuel_block:2>, null, <projecte:fuel_block:2>, <projecte:fuel_block:2>],
+[<projecte:fuel_block:2>, <contenttweaker:nebulous_soul>, <appliedenergistics2:fluix_block>, <contenttweaker:nebulous_soul>, <projecte:fuel_block:2>],
+[null, <appliedenergistics2:fluix_block>, <projecte:alchemical_chest>, <appliedenergistics2:fluix_block>, null],
+[<projecte:fuel_block:2>, <contenttweaker:nebulous_soul>, <appliedenergistics2:fluix_block>, <contenttweaker:nebulous_soul>, <projecte:fuel_block:2>],
+[<projecte:fuel_block:2>, <projecte:fuel_block:2>, null, <projecte:fuel_block:2>, <projecte:fuel_block:2>]]);
+
+recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module_tablet:0>, <rftools:storage_module:1>]);
+recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module_tablet:0>, <rftools:storage_module:2>]);
+recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module_tablet:0>, <rftools:storage_module:6>]);
+recipes.addShapeless(<rftools:storage_module_tablet:2>, [<rftools:storage_module_tablet:0>, <rftools:storage_control_module>]);

--- a/scripts/RFToolsGating.zs
+++ b/scripts/RFToolsGating.zs
@@ -207,22 +207,22 @@ mods.extendedcrafting.TableCrafting.addShaped(<rftools:storage_module_tablet>,
 [<projecte:fuel_block:2>, <contenttweaker:nebulous_soul>, <appliedenergistics2:fluix_block>, <contenttweaker:nebulous_soul>, <projecte:fuel_block:2>],
 [<projecte:fuel_block:2>, <projecte:fuel_block:2>, null, <projecte:fuel_block:2>, <projecte:fuel_block:2>]]);
 
-recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module_tablet:0>, <rftools:storage_module:1>.marked("module")], function(out, ins) {
+recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module_tablet:0>, <rftools:storage_module:1>.marked("module")] as IIngredient[], function(out, ins, cInfo) {
     return out.withTag(ins.module.tag).withDamage(0).updateTag({
         childDamage: ins.module.damage
     });
 });
-recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module_tablet:0>, <rftools:storage_module:2>.marked("module")], function(out, ins) {
+recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module_tablet:0>, <rftools:storage_module:2>.marked("module")] as IIngredient[], function(out, ins, cInfo) {
     return out.withTag(ins.module.tag).withDamage(0).updateTag({
         childDamage: ins.module.damage
     });
 });
-recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module_tablet:0>, <rftools:storage_module:6>.marked("module")], function(out, ins) {
+recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module_tablet:0>, <rftools:storage_module:6>.marked("module")]as IIngredient[], function(out, ins, cInfo) {
     return out.withTag(ins.module.tag).withDamage(0).updateTag({
         childDamage: ins.module.damage
     });
 });
-recipes.addShapeless(<rftools:storage_module_tablet:2>, [<rftools:storage_module_tablet:0>, <rftools:storage_control_module>.marked("module")], function(out, ins) {
+recipes.addShapeless(<rftools:storage_module_tablet:2>, [<rftools:storage_module_tablet:0>, <rftools:storage_control_module>.marked("module")]as IIngredient[], function(out, ins, cInfo) {
     return out.withTag(ins.module.tag).withDamage(0).updateTag({
         childDamage: 666
     });

--- a/scripts/RFToolsGating.zs
+++ b/scripts/RFToolsGating.zs
@@ -205,7 +205,23 @@ mods.extendedcrafting.TableCrafting.addShaped(<rftools:storage_module_tablet>,
 [<projecte:fuel_block:2>, <contenttweaker:nebulous_soul>, <appliedenergistics2:fluix_block>, <contenttweaker:nebulous_soul>, <projecte:fuel_block:2>],
 [<projecte:fuel_block:2>, <projecte:fuel_block:2>, null, <projecte:fuel_block:2>, <projecte:fuel_block:2>]]);
 
-recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module_tablet:0>, <rftools:storage_module:1>]);
-recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module_tablet:0>, <rftools:storage_module:2>]);
-recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module_tablet:0>, <rftools:storage_module:6>]);
-recipes.addShapeless(<rftools:storage_module_tablet:2>, [<rftools:storage_module_tablet:0>, <rftools:storage_control_module>]);
+recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module_tablet:0>, <rftools:storage_module:1>.mark("module")], function(out, ins, cInfo) {
+    return out.withTag(ins.module.tag).withDamage(0).updateTag({
+        childDamage: ins.module.damage
+    });
+});
+recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module_tablet:0>, <rftools:storage_module:2>.mark("module")], function(out, ins, cInfo) {
+    return out.withTag(ins.module.tag).withDamage(0).updateTag({
+        childDamage: ins.module.damage
+    });
+});
+recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module_tablet:0>, <rftools:storage_module:6>.mark("module")], function(out, ins, cInfo) {
+    return out.withTag(ins.module.tag).withDamage(0).updateTag({
+        childDamage: ins.module.damage
+    });
+});
+recipes.addShapeless(<rftools:storage_module_tablet:2>, [<rftools:storage_module_tablet:0>, <rftools:storage_control_module>.mark("module")], function(out, ins, cInfo) {
+    return out.withTag(ins.module.tag).withDamage(0).updateTag({
+        childDamage: 666
+    });
+});

--- a/scripts/RFToolsGating.zs
+++ b/scripts/RFToolsGating.zs
@@ -2,45 +2,45 @@ import crafttweaker.item.IIngredient;
 
 recipes.removeShaped(<rftools:builder>);
 
-mods.extendedcrafting.TableCrafting.addShaped(<rftools:builder>, 
-[[<railcraft:coke_oven:0>, <tconstruct:materials:2>, <tconstruct:materials:2>, <ore:gearDiamond>, <tconstruct:materials:2>, <tconstruct:materials:2>, <railcraft:coke_oven:0>], 
-[<tconstruct:materials:2>, <divinerpg:realmite_ingot>, null, null, null, <divinerpg:realmite_ingot>, <tconstruct:materials:2>], 
-[<tconstruct:materials:2>, null, <contenttweaker:living_gold>, <actuallyadditions:item_crystal:0>, <contenttweaker:living_gold>, null, <tconstruct:materials:2>], 
-[<ore:gearDiamond>, null, <actuallyadditions:item_crystal:0>, <rftools:machine_frame>, <actuallyadditions:item_crystal:0>, null, <ore:gearDiamond>], 
-[<tconstruct:materials:2>, null, <contenttweaker:living_gold>, <actuallyadditions:item_crystal:0>, <contenttweaker:living_gold>, null, <tconstruct:materials:2>], 
-[<tconstruct:materials:2>, <divinerpg:realmite_ingot>, null, null, null, <divinerpg:realmite_ingot>, <tconstruct:materials:2>], 
-[<railcraft:coke_oven:0>, <tconstruct:materials:2>, <tconstruct:materials:2>, <ore:gearDiamond>, <tconstruct:materials:2>, <tconstruct:materials:2>, <railcraft:coke_oven:0>]]);  
+mods.extendedcrafting.TableCrafting.addShaped(<rftools:builder>,
+[[<railcraft:coke_oven:0>, <tconstruct:materials:2>, <tconstruct:materials:2>, <ore:gearDiamond>, <tconstruct:materials:2>, <tconstruct:materials:2>, <railcraft:coke_oven:0>],
+[<tconstruct:materials:2>, <divinerpg:realmite_ingot>, null, null, null, <divinerpg:realmite_ingot>, <tconstruct:materials:2>],
+[<tconstruct:materials:2>, null, <contenttweaker:living_gold>, <actuallyadditions:item_crystal:0>, <contenttweaker:living_gold>, null, <tconstruct:materials:2>],
+[<ore:gearDiamond>, null, <actuallyadditions:item_crystal:0>, <rftools:machine_frame>, <actuallyadditions:item_crystal:0>, null, <ore:gearDiamond>],
+[<tconstruct:materials:2>, null, <contenttweaker:living_gold>, <actuallyadditions:item_crystal:0>, <contenttweaker:living_gold>, null, <tconstruct:materials:2>],
+[<tconstruct:materials:2>, <divinerpg:realmite_ingot>, null, null, null, <divinerpg:realmite_ingot>, <tconstruct:materials:2>],
+[<railcraft:coke_oven:0>, <tconstruct:materials:2>, <tconstruct:materials:2>, <ore:gearDiamond>, <tconstruct:materials:2>, <tconstruct:materials:2>, <railcraft:coke_oven:0>]]);
 
 recipes.removeShaped(<rftools:machine_frame>);
 
-mods.extendedcrafting.TableCrafting.addShaped(<rftools:machine_frame>, 
-[[<tconstruct:ingots:5>, <minecraft:dye:4>, <tconstruct:ingots:5>], 
-[<bigreactors:ingotyellorium>, null, <bigreactors:ingotyellorium>], 
-[<tconstruct:ingots:5>, <minecraft:dye:4>, <tconstruct:ingots:5>]]); 
+mods.extendedcrafting.TableCrafting.addShaped(<rftools:machine_frame>,
+[[<tconstruct:ingots:5>, <minecraft:dye:4>, <tconstruct:ingots:5>],
+[<bigreactors:ingotyellorium>, null, <bigreactors:ingotyellorium>],
+[<tconstruct:ingots:5>, <minecraft:dye:4>, <tconstruct:ingots:5>]]);
 
 mods.botania.PureDaisy.addRecipe(<minecraft:gold_block>,<contenttweaker:living_gold>, 100);
 
 recipes.removeShaped(<rftools:matter_transmitter>);
 
-mods.extendedcrafting.TableCrafting.addShaped(<rftools:matter_transmitter>, 
-[[<minecraft:ender_pearl>, <minecraft:ender_pearl>, null, null, null, <minecraft:ender_pearl>, <minecraft:ender_pearl>], 
-[<minecraft:ender_pearl>, <dimdoors:world_thread>, null, null, null, <dimdoors:world_thread>, <minecraft:ender_pearl>], 
-[null, null, <projecte:item.pe_matter:0>, <projecte:item.pe_matter:0>, <projecte:item.pe_matter:0>, null, null], 
-[null, null, <minecraft:redstone>, <rftools:machine_frame>, <minecraft:redstone>, null, null], 
-[null, null, <divinerpg:shadow_bar>, <divinerpg:shadow_bar>, <divinerpg:shadow_bar>, null, null], 
-[<minecraft:ender_pearl>, <dimdoors:world_thread>, null, null, null, <dimdoors:world_thread>, <minecraft:ender_pearl>], 
-[<minecraft:ender_pearl>, <minecraft:ender_pearl>, null, null, null, <minecraft:ender_pearl>, <minecraft:ender_pearl>]]);  
+mods.extendedcrafting.TableCrafting.addShaped(<rftools:matter_transmitter>,
+[[<minecraft:ender_pearl>, <minecraft:ender_pearl>, null, null, null, <minecraft:ender_pearl>, <minecraft:ender_pearl>],
+[<minecraft:ender_pearl>, <dimdoors:world_thread>, null, null, null, <dimdoors:world_thread>, <minecraft:ender_pearl>],
+[null, null, <projecte:item.pe_matter:0>, <projecte:item.pe_matter:0>, <projecte:item.pe_matter:0>, null, null],
+[null, null, <minecraft:redstone>, <rftools:machine_frame>, <minecraft:redstone>, null, null],
+[null, null, <divinerpg:shadow_bar>, <divinerpg:shadow_bar>, <divinerpg:shadow_bar>, null, null],
+[<minecraft:ender_pearl>, <dimdoors:world_thread>, null, null, null, <dimdoors:world_thread>, <minecraft:ender_pearl>],
+[<minecraft:ender_pearl>, <minecraft:ender_pearl>, null, null, null, <minecraft:ender_pearl>, <minecraft:ender_pearl>]]);
 
 recipes.removeShaped(<rftools:matter_receiver>);
 
-mods.extendedcrafting.TableCrafting.addShaped(<rftools:matter_receiver>, 
-[[<minecraft:ender_pearl>, <minecraft:ender_pearl>, null, null, null, <minecraft:ender_pearl>, <minecraft:ender_pearl>], 
-[<minecraft:ender_pearl>, <dimdoors:world_thread>, null, null, null, <dimdoors:world_thread>, <minecraft:ender_pearl>], 
-[null, null, <divinerpg:shadow_bar>, <divinerpg:shadow_bar>, <divinerpg:shadow_bar>, null, null], 
-[null, null, <minecraft:redstone>, <rftools:machine_frame>, <minecraft:redstone>, null, null], 
-[null, null, <projecte:item.pe_matter:0>, <projecte:item.pe_matter:0>, <projecte:item.pe_matter:0>, null, null], 
-[<minecraft:ender_pearl>, <dimdoors:world_thread>, null, null, null, <dimdoors:world_thread>, <minecraft:ender_pearl>], 
-[<minecraft:ender_pearl>, <minecraft:ender_pearl>, null, null, null, <minecraft:ender_pearl>, <minecraft:ender_pearl>]]);  
+mods.extendedcrafting.TableCrafting.addShaped(<rftools:matter_receiver>,
+[[<minecraft:ender_pearl>, <minecraft:ender_pearl>, null, null, null, <minecraft:ender_pearl>, <minecraft:ender_pearl>],
+[<minecraft:ender_pearl>, <dimdoors:world_thread>, null, null, null, <dimdoors:world_thread>, <minecraft:ender_pearl>],
+[null, null, <divinerpg:shadow_bar>, <divinerpg:shadow_bar>, <divinerpg:shadow_bar>, null, null],
+[null, null, <minecraft:redstone>, <rftools:machine_frame>, <minecraft:redstone>, null, null],
+[null, null, <projecte:item.pe_matter:0>, <projecte:item.pe_matter:0>, <projecte:item.pe_matter:0>, null, null],
+[<minecraft:ender_pearl>, <dimdoors:world_thread>, null, null, null, <dimdoors:world_thread>, <minecraft:ender_pearl>],
+[<minecraft:ender_pearl>, <minecraft:ender_pearl>, null, null, null, <minecraft:ender_pearl>, <minecraft:ender_pearl>]]);
 
 recipes.removeShaped(<rftools:charged_porter>);
 
@@ -56,65 +56,65 @@ recipes.removeShaped(<rftoolsdim:dimension_builder>);
 
 recipes.removeShaped(<rftoolsdim:empty_dimension_tab>);
 
-mods.extendedcrafting.TableCrafting.addShaped(<rftoolsdim:empty_dimension_tab>, 
-[[<minecraft:paper>, <woot:prism>, null, null, null, <woot:prism>, <minecraft:paper>], 
-[<woot:prism>, <minecraft:paper>, null, null, null, <minecraft:paper>, <woot:prism>], 
-[null, null, <minecraft:paper>, <woot:shard:6>, <minecraft:paper>, null, null], 
-[null, null, <woot:shard:6>, <rftools:machine_frame>, <woot:shard:6>, null, null], 
-[null, null, <minecraft:paper>, <woot:shard:6>, <minecraft:paper>, null, null], 
-[<woot:prism>, <minecraft:paper>, null, null, null, <minecraft:paper>, <woot:prism>], 
-[<minecraft:paper>, <woot:prism>, null, null, null, <woot:prism>, <minecraft:paper>]]);  
+mods.extendedcrafting.TableCrafting.addShaped(<rftoolsdim:empty_dimension_tab>,
+[[<minecraft:paper>, <woot:prism>, null, null, null, <woot:prism>, <minecraft:paper>],
+[<woot:prism>, <minecraft:paper>, null, null, null, <minecraft:paper>, <woot:prism>],
+[null, null, <minecraft:paper>, <woot:shard:6>, <minecraft:paper>, null, null],
+[null, null, <woot:shard:6>, <rftools:machine_frame>, <woot:shard:6>, null, null],
+[null, null, <minecraft:paper>, <woot:shard:6>, <minecraft:paper>, null, null],
+[<woot:prism>, <minecraft:paper>, null, null, null, <minecraft:paper>, <woot:prism>],
+[<minecraft:paper>, <woot:prism>, null, null, null, <woot:prism>, <minecraft:paper>]]);
 
 recipes.remove(<rftools:coalgenerator>);
 
 recipes.removeShaped(<rftoolsdim:dimension_enscriber>);
 
-mods.extendedcrafting.TableCrafting.addShaped(<rftoolsdim:dimension_enscriber>, 
-[[<contenttweaker:mythic_excavation_reactor>, <contenttweaker:charged_dyson_capacitor>, <contenttweaker:infinity_plate>, <tconstruct:pan_head>.withTag({Material: "infinity_avaritia_plustic"}), <contenttweaker:infinity_plate>, <contenttweaker:charged_dyson_capacitor>, <contenttweaker:mythic_excavation_reactor>], 
-[<contenttweaker:charged_dyson_capacitor>, <contenttweaker:collapser_conduit>, <contenttweaker:neutronium_cannon>, <contenttweaker:dyson_collector>, <draconicevolution:reactor_component:0>, <contenttweaker:collapser_conduit>, <contenttweaker:charged_dyson_capacitor>], 
-[<contenttweaker:infinity_plate>, <draconicevolution:reactor_component:0>, <rftools:remote_scanner>, <rftools:scanner>, <rftools:remote_scanner>, <contenttweaker:neutronium_cannon>, <contenttweaker:infinity_plate>], 
-[<tconstruct:pan_head>.withTag({Material: "infinity_avaritia_plustic"}), <contenttweaker:dyson_collector>, <rftools:projector>, <rftools:machine_frame>, <rftools:projector>, <contenttweaker:dyson_collector>, <tconstruct:pan_head>.withTag({Material: "infinity_avaritia_plustic"})], 
-[<contenttweaker:infinity_plate>, <contenttweaker:neutronium_cannon>, <rftools:remote_scanner>, <rftools:scanner>, <rftools:remote_scanner>, <draconicevolution:reactor_component:0>, <contenttweaker:infinity_plate>], 
-[<contenttweaker:charged_dyson_capacitor>, <contenttweaker:collapser_conduit>, <draconicevolution:reactor_component:0>, <contenttweaker:dyson_collector>, <contenttweaker:neutronium_cannon>, <contenttweaker:collapser_conduit>, <contenttweaker:charged_dyson_capacitor>], 
-[<contenttweaker:mythic_excavation_reactor>, <contenttweaker:charged_dyson_capacitor>, <contenttweaker:infinity_plate>, <tconstruct:pan_head>.withTag({Material: "infinity_avaritia_plustic"}), <contenttweaker:infinity_plate>, <contenttweaker:charged_dyson_capacitor>, <contenttweaker:mythic_excavation_reactor>]]);  
+mods.extendedcrafting.TableCrafting.addShaped(<rftoolsdim:dimension_enscriber>,
+[[<contenttweaker:mythic_excavation_reactor>, <contenttweaker:charged_dyson_capacitor>, <contenttweaker:infinity_plate>, <tconstruct:pan_head>.withTag({Material: "infinity_avaritia_plustic"}), <contenttweaker:infinity_plate>, <contenttweaker:charged_dyson_capacitor>, <contenttweaker:mythic_excavation_reactor>],
+[<contenttweaker:charged_dyson_capacitor>, <contenttweaker:collapser_conduit>, <contenttweaker:neutronium_cannon>, <contenttweaker:dyson_collector>, <draconicevolution:reactor_component:0>, <contenttweaker:collapser_conduit>, <contenttweaker:charged_dyson_capacitor>],
+[<contenttweaker:infinity_plate>, <draconicevolution:reactor_component:0>, <rftools:remote_scanner>, <rftools:scanner>, <rftools:remote_scanner>, <contenttweaker:neutronium_cannon>, <contenttweaker:infinity_plate>],
+[<tconstruct:pan_head>.withTag({Material: "infinity_avaritia_plustic"}), <contenttweaker:dyson_collector>, <rftools:projector>, <rftools:machine_frame>, <rftools:projector>, <contenttweaker:dyson_collector>, <tconstruct:pan_head>.withTag({Material: "infinity_avaritia_plustic"})],
+[<contenttweaker:infinity_plate>, <contenttweaker:neutronium_cannon>, <rftools:remote_scanner>, <rftools:scanner>, <rftools:remote_scanner>, <draconicevolution:reactor_component:0>, <contenttweaker:infinity_plate>],
+[<contenttweaker:charged_dyson_capacitor>, <contenttweaker:collapser_conduit>, <draconicevolution:reactor_component:0>, <contenttweaker:dyson_collector>, <contenttweaker:neutronium_cannon>, <contenttweaker:collapser_conduit>, <contenttweaker:charged_dyson_capacitor>],
+[<contenttweaker:mythic_excavation_reactor>, <contenttweaker:charged_dyson_capacitor>, <contenttweaker:infinity_plate>, <tconstruct:pan_head>.withTag({Material: "infinity_avaritia_plustic"}), <contenttweaker:infinity_plate>, <contenttweaker:charged_dyson_capacitor>, <contenttweaker:mythic_excavation_reactor>]]);
 
 
-mods.extendedcrafting.TableCrafting.addShaped(<rftoolsdim:dimension_builder>, 
-[[<contenttweaker:charged_dyson_capacitor>, <contenttweaker:charged_dyson_capacitor>, <contenttweaker:charged_dyson_capacitor>, 
-<contenttweaker:charged_dyson_capacitor>, <advancedrocketry:gravitymachine>, <contenttweaker:charged_dyson_capacitor>, 
-<contenttweaker:charged_dyson_capacitor>, <contenttweaker:charged_dyson_capacitor>, <contenttweaker:charged_dyson_capacitor>], 
+mods.extendedcrafting.TableCrafting.addShaped(<rftoolsdim:dimension_builder>,
+[[<contenttweaker:charged_dyson_capacitor>, <contenttweaker:charged_dyson_capacitor>, <contenttweaker:charged_dyson_capacitor>,
+<contenttweaker:charged_dyson_capacitor>, <advancedrocketry:gravitymachine>, <contenttweaker:charged_dyson_capacitor>,
+<contenttweaker:charged_dyson_capacitor>, <contenttweaker:charged_dyson_capacitor>, <contenttweaker:charged_dyson_capacitor>],
 
-[<botania:specialflower>.withTag({type: "dandelifeon"}), null, <contenttweaker:mythic_excavation_reactor>, 
-null, <bewitchment:stew_of_the_grotesque>, null, 
-<contenttweaker:mythic_excavation_reactor>, null, <botania:specialflower>.withTag({type: "dandelifeon"})], 
+[<botania:specialflower>.withTag({type: "dandelifeon"}), null, <contenttweaker:mythic_excavation_reactor>,
+null, <bewitchment:stew_of_the_grotesque>, null,
+<contenttweaker:mythic_excavation_reactor>, null, <botania:specialflower>.withTag({type: "dandelifeon"})],
 
-[null, <contenttweaker:hypercubic_energy_orb>, null, 
-<rftools:space_chamber_controller>, <tconstruct:toolforge>.withTag({textureBlock: {id: "avaritia:block_resource", Count: 1, Damage: 1 as short}}), <rftools:space_chamber_controller>, 
-null, <contenttweaker:hypercubic_energy_orb>, null], 
+[null, <contenttweaker:hypercubic_energy_orb>, null,
+<rftools:space_chamber_controller>, <tconstruct:toolforge>.withTag({textureBlock: {id: "avaritia:block_resource", Count: 1, Damage: 1 as short}}), <rftools:space_chamber_controller>,
+null, <contenttweaker:hypercubic_energy_orb>, null],
 
-[<extendedcrafting:storage:4>, null, null, 
-null, <draconicevolution:chaotic_core>, null, 
-null, null, <extendedcrafting:storage:4>], 
+[<extendedcrafting:storage:4>, null, null,
+null, <draconicevolution:chaotic_core>, null,
+null, null, <extendedcrafting:storage:4>],
 
-[<extendedcrafting:storage:4>, null, null, 
-<draconicevolution:chaotic_core>, <draconicevolution:reactor_core>, <draconicevolution:chaotic_core>, 
-null, null, <extendedcrafting:storage:4>], 
+[<extendedcrafting:storage:4>, null, null,
+<draconicevolution:chaotic_core>, <draconicevolution:reactor_core>, <draconicevolution:chaotic_core>,
+null, null, <extendedcrafting:storage:4>],
 
-[<extendedcrafting:storage:4>, null, null, 
-null, <draconicevolution:chaotic_core>, null, 
-null, null, <extendedcrafting:storage:4>], 
+[<extendedcrafting:storage:4>, null, null,
+null, <draconicevolution:chaotic_core>, null,
+null, null, <extendedcrafting:storage:4>],
 
-[null, <contenttweaker:hypercubic_energy_orb>, null, 
-<rftools:space_chamber_controller>, <tconstruct:toolforge>.withTag({textureBlock: {id: "avaritia:block_resource", Count: 1, Damage: 1 as short}}), <rftools:space_chamber_controller>, 
-null, <contenttweaker:hypercubic_energy_orb>, null], 
+[null, <contenttweaker:hypercubic_energy_orb>, null,
+<rftools:space_chamber_controller>, <tconstruct:toolforge>.withTag({textureBlock: {id: "avaritia:block_resource", Count: 1, Damage: 1 as short}}), <rftools:space_chamber_controller>,
+null, <contenttweaker:hypercubic_energy_orb>, null],
 
-[<botania:specialflower>.withTag({type: "dandelifeon"}), null, <contenttweaker:mythic_excavation_reactor>, 
-null, <bewitchment:stew_of_the_grotesque>, null, 
-<contenttweaker:mythic_excavation_reactor>, null, <botania:specialflower>.withTag({type: "dandelifeon"})], 
+[<botania:specialflower>.withTag({type: "dandelifeon"}), null, <contenttweaker:mythic_excavation_reactor>,
+null, <bewitchment:stew_of_the_grotesque>, null,
+<contenttweaker:mythic_excavation_reactor>, null, <botania:specialflower>.withTag({type: "dandelifeon"})],
 
-[<advancedrocketry:terraformer>, <contenttweaker:charged_dyson_capacitor>, <contenttweaker:charged_dyson_capacitor>, 
-<contenttweaker:charged_dyson_capacitor>, <contenttweaker:charged_dyson_capacitor>, <contenttweaker:charged_dyson_capacitor>, 
-<contenttweaker:charged_dyson_capacitor>, <contenttweaker:charged_dyson_capacitor>, <draconicevolution:celestial_manipulator>]]);  
+[<advancedrocketry:terraformer>, <contenttweaker:charged_dyson_capacitor>, <contenttweaker:charged_dyson_capacitor>,
+<contenttweaker:charged_dyson_capacitor>, <contenttweaker:charged_dyson_capacitor>, <contenttweaker:charged_dyson_capacitor>,
+<contenttweaker:charged_dyson_capacitor>, <contenttweaker:charged_dyson_capacitor>, <draconicevolution:celestial_manipulator>]]);
 
 
 recipes.addShaped(<rftoolsdim:dimension_builder>*2,

--- a/scripts/RFToolsGating.zs
+++ b/scripts/RFToolsGating.zs
@@ -1,3 +1,5 @@
+import crafttweaker.item.IIngredient;
+
 recipes.removeShaped(<rftools:builder>);
 
 mods.extendedcrafting.TableCrafting.addShaped(<rftools:builder>, 

--- a/scripts/RFToolsGating.zs
+++ b/scripts/RFToolsGating.zs
@@ -205,22 +205,22 @@ mods.extendedcrafting.TableCrafting.addShaped(<rftools:storage_module_tablet>,
 [<projecte:fuel_block:2>, <contenttweaker:nebulous_soul>, <appliedenergistics2:fluix_block>, <contenttweaker:nebulous_soul>, <projecte:fuel_block:2>],
 [<projecte:fuel_block:2>, <projecte:fuel_block:2>, null, <projecte:fuel_block:2>, <projecte:fuel_block:2>]]);
 
-recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module_tablet:0>, <rftools:storage_module:1>.mark("module")], function(out, ins, cInfo) {
+recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module_tablet:0>, <rftools:storage_module:1>.marked("module")], function(out, ins) {
     return out.withTag(ins.module.tag).withDamage(0).updateTag({
         childDamage: ins.module.damage
     });
 });
-recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module_tablet:0>, <rftools:storage_module:2>.mark("module")], function(out, ins, cInfo) {
+recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module_tablet:0>, <rftools:storage_module:2>.marked("module")], function(out, ins) {
     return out.withTag(ins.module.tag).withDamage(0).updateTag({
         childDamage: ins.module.damage
     });
 });
-recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module_tablet:0>, <rftools:storage_module:6>.mark("module")], function(out, ins, cInfo) {
+recipes.addShapeless(<rftools:storage_module_tablet:1>, [<rftools:storage_module_tablet:0>, <rftools:storage_module:6>.marked("module")], function(out, ins) {
     return out.withTag(ins.module.tag).withDamage(0).updateTag({
         childDamage: ins.module.damage
     });
 });
-recipes.addShapeless(<rftools:storage_module_tablet:2>, [<rftools:storage_module_tablet:0>, <rftools:storage_control_module>.mark("module")], function(out, ins, cInfo) {
+recipes.addShapeless(<rftools:storage_module_tablet:2>, [<rftools:storage_module_tablet:0>, <rftools:storage_control_module>.marked("module")], function(out, ins) {
     return out.withTag(ins.module.tag).withDamage(0).updateTag({
         childDamage: 666
     });


### PR DESCRIPTION
Not sure when this got broken but I think it happened in 1.16.5.

The RFTools Storage Tablet needs to be combined with either a Storage Module or a Storage Scanner Screen Module to be usable at all. Because of the changes introduced in f7532d1 (specifically [L200 of RFToolsGating.zs](https://github.com/sainagh/meatballcraft/blob/main/scripts/RFToolsGating.zs#L200)) where the shaped recipes for the Storage Tablet are removed you can no longer craft the tablet together with a module to make it functional.

This pull request re-adds the recipes to combine the tablet with the various module types (the three tiers of storage modules available in the mod pack plus the scanner screen module) and, additionally, makes them shapeless.

Tested this on my private server using the latest version of the pack plus this change in isolation.

![image](https://github.com/user-attachments/assets/43a341c6-1f5a-4df5-a3e2-2d68459e5b2c)