### PR TITLE
Fix dupe with the epic tool tipper

### DIFF
--- a/scripts/EpicToolTipper.zs
+++ b/scripts/EpicToolTipper.zs
@@ -23,7 +23,7 @@ recipes.addShapeless(
         var updatedTag as IData = {
 		    display: {Lore: ["§d§oSuper-Enchanted§r"]}
 		};
-		return ins.mark.updateTag(inpuTag += updatedTag);
+		return ins.mark.updateTag(inpuTag += updatedTag).withAmount(1);
     },
     null
 );


### PR DESCRIPTION
The epic tool tipper copied the input stacks size, but only decremented it by one, so if you had two of a stackable item tool tip them both at the same time to dupe them.