### PR TITLE
Fix potions brewing into Extra Utilities potions

### DIFF
--- a/scripts/RecipeConflicts.zs
+++ b/scripts/RecipeConflicts.zs
@@ -2236,17 +2236,6 @@ mods.immersiveengineering.ArcFurnace.removeRecipe(<materialpart:ichorium:ingot>)
 mods.immersiveengineering.ArcFurnace.removeRecipe(<contenttweaker:material_part:309>);
 
 
-brewing.removeRecipe(<minecraft:potion>.withTag({Potion: "mod_lavacow:strong_corrosive"}), <minecraft:sugar>);
-
-brewing.addBrew(<minecraft:potion>.withTag({Potion: "mod_lavacow:corrosive"}), <ore:salt>, <minecraft:potion>.withTag({Potion: "mod_lavacow:strong_corrosive"}));
-
-
-
-brewing.removeRecipe(<minecraft:potion>.withTag({Potion: "extrautils2:xu2.doom"}), <minecraft:gunpowder>);
-
-brewing.removeRecipe(<minecraft:potion>.withTag({Potion: "extrautils2:xu2.gravity.long"}), <minecraft:redstone>);
-
-
 recipes.remove(<xtones:base>);
 recipes.addShaped(<xtones:base>*4,
 [[<ore:slabStone>, <ore:slabStone>, null],


### PR DESCRIPTION
**Requires updating XU2-Patcher to v1.0.2!**
Fixes longstanding issue where potions couldn't be brewed normally because they would turn into XU2 potions of gravity/doom/etc. Removes manual fixes in `RecipeConflicts.zs` as they are unnecessary now.

See Kanzaji/XU2-Patcher#6 for more details.