### PR TITLE
Unify thaumcraft plates in research rewards

### DIFF
--- a/scripts/thaumcraft/Unifier.zs
+++ b/scripts/thaumcraft/Unifier.zs
@@ -1,0 +1,27 @@
+#modloaded thaumcraft
+#loader lateAddTC
+#priority 10
+
+import native.net.minecraft.item.ItemStack;
+
+import crafttweaker.item.IItemStack;
+
+static unifiedPlates as IItemStack[IItemStack] = {
+  <thaumcraft:plate:0>: <techreborn:plates:18>,                 // brass
+  <thaumcraft:plate:1>: <thermalfoundation:material:32>,        // iron
+  <bewitchment:silver_plate>: <thermalfoundation:material:322>, // silver
+};
+
+function unifyStack(stackIn as ItemStack, unifiedDict as IItemStack[IItemStack]) as ItemStack {
+  var stack as IItemStack = stackIn.wrapper;
+  for original, unified in unifiedDict {
+    if (stack.anyAmount().matches(original)) {
+      return (unified * stack.amount).native;
+    }
+  }
+  return stackIn;
+}
+
+function unifyPlates(stackIn as ItemStack) as ItemStack {
+  return unifyStack(stackIn, unifiedPlates);
+}

--- a/scripts/thaumcraft/UnifyGolemMaterials.zs
+++ b/scripts/thaumcraft/UnifyGolemMaterials.zs
@@ -6,20 +6,16 @@ import native.thaumcraft.api.golems.parts.GolemHead;
 import native.thaumcraft.api.golems.parts.GolemLeg;
 
 import crafttweaker.item.IItemStack;
+
+import scripts.thaumcraft.Unifier;
 /*
 Unify plates visually shown in the golem press.
 */
-var unifiedPlates = {
-  <thaumcraft:plate:0>: <techreborn:plates:18>,                 // brass
-  <thaumcraft:plate:1>: <thermalfoundation:material:32>,        // iron
-  <bewitchment:silver_plate>: <thermalfoundation:material:322>, // silver
-} as IItemStack[IItemStack];
-
 # Materials
 for material in GolemMaterial.getMaterials() {
   if (isStackValid(material.componentBase)) {
     var baseComponent as IItemStack = material.componentBase.wrapper;
-    material.componentBase = unifyStack(baseComponent, unifiedPlates);
+    material.componentBase = Unifier.unifyPlates(baseComponent);
   }
 }
 # Head
@@ -29,7 +25,7 @@ for head in GolemHead.getHeads() {
     var component = components[i];
     if (component instanceof ItemStack && isStackValid(component as ItemStack)) {
       var stack as IItemStack = (component as ItemStack).wrapper;
-      components[i] = unifyStack(stack, unifiedPlates);
+      components[i] = Unifier.unifyPlates(stack);
     }
   }
 }
@@ -40,21 +36,11 @@ for leg in GolemLeg.getLegs() {
     var component = components[i];
     if (component instanceof ItemStack && isStackValid(component as ItemStack)) {
       var stack as IItemStack = (component as ItemStack).wrapper;
-      components[i] = unifyStack(stack, unifiedPlates);
+      components[i] = Unifier.unifyPlates(stack);
     }
   }
 }
 
 function isStackValid(stack as ItemStack) as bool {
   return !(isNull(stack) || stack.isEmpty());
-}
-
-function unifyStack(stackIn as ItemStack, unifiedDict as IItemStack[IItemStack]) as ItemStack {
-  var stack as IItemStack = stackIn.wrapper;
-  for original, unified in unifiedDict {
-    if (stack.anyAmount().matches(original)) {
-      return (unified * stack.amount).native;
-    }
-  }
-  return stackIn;
 }

--- a/scripts/thaumcraft/research/LateResearch.zs
+++ b/scripts/thaumcraft/research/LateResearch.zs
@@ -1,15 +1,20 @@
 #modloaded thaumcraft
 #loader lateAddTC
+
 import native.net.minecraft.item.ItemStack;
 import native.thaumcraft.api.research.ResearchCategories;
 import native.thaumcraft.api.research.ResearchStage;
 
 import crafttweaker.item.IItemStack;
 
+import scripts.thaumcraft.Unifier;
+
 /*
-Hard-coded, non-JSON, research pages to replace crafting requirements for consume requirements.
+Hard-coded, non-JSON, research pages to edit.
+- Replaces crafting requirements for consume requirements.
 This is so we can make these ingredients obtainable through non-crafting recipes,
 but still make associated research completable.
+- Unifies plates from rewards.
 
 See config/thaumcraftfix/patches for research page changes that are JSON-based.
 */
@@ -40,6 +45,9 @@ convertCraftToConsume(t3SmelterStage, mithminitePlate);
 
 var scytheStage = findCraftingStage("TAR_MITHMINITE_SCYTHE", mithminitePlate);
 convertCraftToConsume(scytheStage, mithminitePlate);
+
+# TC plate unification
+convertRewardItems("TAR_CRYSTAL_CRUSHER", Unifier.unifiedPlates);
 
 function findCraftingStage(researchName as string, targetItem as IItemStack) as ResearchStage {
   var stages = ResearchCategories.getResearch(researchName).getStages();
@@ -78,5 +86,13 @@ function convertCraftToConsume(stage as ResearchStage, itemToConvert as IItemSta
     stage.setObtain([itemToConvert.native] as ItemStack[]);
   } else {
     stage.setObtain((consumed as ItemStack[]) + itemToConvert.native);
+  }
+}
+
+function convertRewardItems(researchName as string, itemsToReplace as IItemStack[IItemStack]) {
+  var rewards = ResearchCategories.getResearch(researchName).getRewardItem();
+  for i in 0 to rewards.length {
+    var reward = rewards[i];
+    rewards[i] = Unifier.unifyStack(reward, itemsToReplace);
   }
 }


### PR DESCRIPTION
Unify one last place where TC brass/iron plates were obtainable. This should mean TC brass/iron plates are completely unobtainable and not used in any recipe.