### PR TITLE
Fixed bug with master spells and other items

### DIFF
--- a/scripts/MasterSpells.zs
+++ b/scripts/MasterSpells.zs
@@ -36,6 +36,9 @@ var masterspellaqua = VanillaFactory.createItem("master_spell_aqua");
 masterspellaqua.maxStackSize = 1;
 masterspellaqua.glowing = true;
 masterspellaqua.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("toggledownfall", player, world, false, true);
 	return "Pass";
 };
@@ -45,6 +48,9 @@ var masterspellgelu = VanillaFactory.createItem("master_spell_gelu");
 masterspellgelu.maxStackSize = 1;
 masterspellgelu.glowing = true;
 masterspellgelu.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("fill ~-5 ~-5 ~-5 ~5 ~5 ~5 bewitchment:perpetual_ice 0 replace minecraft:ice", player, world, false, true);
 	Commands.call("fill ~-5 ~-5 ~-5 ~5 ~5 ~5 divinerpg:frozen_grass 0 replace minecraft:grass", player, world, false, true);
 	Commands.call("fill ~-5 ~-5 ~-5 ~5 ~5 ~5 divinerpg:frozen_dirt 0 replace minecraft:dirt", player, world, false, true);
@@ -59,6 +65,9 @@ var masterspellsol = VanillaFactory.createItem("master_spell_sol");
 masterspellsol.maxStackSize = 1;
 masterspellsol.glowing = true;
 masterspellsol.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("time add 24000", player, world, false, true);
 	return "Pass";
 };
@@ -68,6 +77,9 @@ var masterspellluna = VanillaFactory.createItem("master_spell_luna");
 masterspellluna.maxStackSize = 1;
 masterspellluna.glowing = true;
 masterspellluna.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("time add 6000", player, world, false, true);
 	return "Pass";
 };
@@ -77,6 +89,9 @@ var masterspellperditio = VanillaFactory.createItem("master_spell_perditio");
 masterspellperditio.maxStackSize = 1;
 masterspellperditio.glowing = true;
 masterspellperditio.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("fill ~10 ~-1 ~10 ~-10 ~-1 ~-10 air 0 replace minecraft:stone 0", player, world, false, true);
 
 	Commands.call("execute @s ~ ~ ~ detect ~ ~-1 ~ bewitchment:blessed_stone 0 fill ~ ~-1 ~ ~ ~-1 ~ air 0 destroy", player, world, false, true);
@@ -92,6 +107,9 @@ var masterspelldesiderium = VanillaFactory.createItem("master_spell_desiderium")
 masterspelldesiderium.maxStackSize = 1;
 masterspelldesiderium.glowing = true;
 masterspelldesiderium.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("fill ~15 ~5 ~15 ~-15 ~-5 ~-15 contenttweaker:living_gold 0", player, world, false, true);
 	return "Pass";
 };
@@ -101,6 +119,9 @@ var masterspellvitium = VanillaFactory.createItem("master_spell_vitium");
 masterspellvitium.maxStackSize = 1;
 masterspellvitium.glowing = true;
 masterspellvitium.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("thaumcraft warp @p set 10000 perm", player, world, false, true);
 	Commands.call("thaumcraft warp @p set 10000 temp", player, world, false, true);
 	Commands.call("summon thaumicaugmentation:eldritch_guardian ~10 ~ ~", player, world, false, true);
@@ -115,6 +136,9 @@ var masterspellterra = VanillaFactory.createItem("master_spell_terra");
 masterspellterra.maxStackSize = 1;
 masterspellterra.glowing = true;
 masterspellterra.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("pillar-spawn master_spell_structure_terra", player, world, false, true);
 	return "Pass";
 };
@@ -124,6 +148,9 @@ var masterspellauram = VanillaFactory.createItem("master_spell_auram");
 masterspellauram.maxStackSize = 1;
 masterspellauram.glowing = true;
 masterspellauram.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("summon Item ~ ~100 ~ {Item:{id:\"thaumadditions:puriflower\",Count:1b}}", player, world, false, true);
 	return "Pass";
 };
@@ -133,10 +160,13 @@ var masterspelllux = VanillaFactory.createItem("master_spell_lux");
 masterspelllux.maxStackSize = 1;
 masterspelllux.glowing = true;
 masterspelllux.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("summon Item ~ ~100 ~ {Item:{id:\"contenttweaker:ineffable_light\",Count:1b}}", player, world, false, true);
-	
+
 	// world.spawnEntity(<contenttweaker:ineffable_light>.createEntityItem(world, player.x, player.y+5, player.z));
-	
+
 	return "Pass";
 };
 masterspelllux.register();
@@ -145,6 +175,9 @@ var masterspeldiabolus = VanillaFactory.createItem("master_spell_diabolus");
 masterspeldiabolus.maxStackSize = 1;
 masterspeldiabolus.glowing = true;
 masterspeldiabolus.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("summon bewitchment:hellhound ~5 ~ ~ {Passengers:[{id:\"bewitchment:demon\",ActiveEffects:[{Id:10,Amplifier:8,Duration:999999},{Id:22,Amplifier:200,Duration:999999}]}]}", player, world, false, true);
 	Commands.call("summon bewitchment:hellhound ~-5 ~ ~ {Passengers:[{id:\"bewitchment:demon\",ActiveEffects:[{Id:10,Amplifier:8,Duration:999999},{Id:22,Amplifier:200,Duration:999999}]}]}", player, world, false, true);
 	Commands.call("summon bewitchment:leonard ~10 ~ ~ {ActiveEffects:[{Id:10,Amplifier:10,Duration:999999},{Id:22,Amplifier:200,Duration:999999}]}", player, world, false, true);
@@ -161,6 +194,9 @@ var masterspelpraemunio = VanillaFactory.createItem("master_spell_praemunio");
 masterspelpraemunio.maxStackSize = 1;
 masterspelpraemunio.glowing = true;
 masterspelpraemunio.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("summon zombie_horse ~ ~1 ~ {Passengers:[{id:zombie,Invulnerable:1,ArmorItems:[{Count:1,id:\"contenttweaker:brightsteel_feet\",tag:{ench:[{id:7,lvl:50}]}},{Count:1,id:\"contenttweaker:brightsteel_legs\",tag:{ench:[{id:7,lvl:20}]}},{Count:1,id:\"contenttweaker:brightsteel_chest\",tag:{ench:[{id:7,lvl:15}]}},{Count:1,id:\"contenttweaker:brightsteel_head\",tag:{ench:[{id:7,lvl:20}]}}],ArmorDropChances:[0.1f,0.1f,0.1f,0.1f]}]}", player, world, false, true);
 	return "Pass";
 };
@@ -172,6 +208,9 @@ var masterspellcaeles = VanillaFactory.createItem("master_spell_caeles");
 masterspellcaeles.maxStackSize = 1;
 masterspellcaeles.glowing = true;
 masterspellcaeles.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("summon Item ~ ~100 ~ {Item:{id:\"contenttweaker:celestial_shield_fragment\",Count:1b}}", player, world, false, true);
 	return "Pass";
 };
@@ -183,6 +222,9 @@ var masterspelldreadia = VanillaFactory.createItem("master_spell_dreadia");
 masterspelldreadia.maxStackSize = 1;
 masterspelldreadia.glowing = true;
 masterspelldreadia.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("summon Item ~ ~10 ~ {Item:{id:\"contenttweaker:bloodmaster_metal_head\",Count:1b}}", player, world, false, true);
 	Commands.call("summon Item ~ ~10 ~ {Item:{id:\"contenttweaker:bloodmaster_metal_chest\",Count:1b}}", player, world, false, true);
 	Commands.call("summon Item ~ ~10 ~ {Item:{id:\"contenttweaker:bloodmaster_metal_feet\",Count:1b}}", player, world, false, true);
@@ -216,6 +258,9 @@ var masterspellmetallum = VanillaFactory.createItem("master_spell_metallum");
 masterspellmetallum.maxStackSize = 1;
 masterspellmetallum.glowing = true;
 masterspellmetallum.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("fill ~-3 ~10 ~-3 ~3 ~10 ~3 minecraft:anvil 0 replace air", player, world, false, true);
 	player.sendChat("You've been Etho'd");
 	return "Pass";
@@ -226,6 +271,9 @@ var masterspellstellae = VanillaFactory.createItem("master_spell_stellae");
 masterspellstellae.maxStackSize = 1;
 masterspellstellae.glowing = true;
 masterspellstellae.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("summon Item ~ ~10 ~ {Item:{id:\"contenttweaker:starlight_sphere\",Count:1b}}", player, world, false, true);
 	return "Pass";
 };
@@ -235,6 +283,9 @@ var masterspellpotentia = VanillaFactory.createItem("master_spell_potentia");
 masterspellpotentia.maxStackSize = 1;
 masterspellpotentia.glowing = true;
 masterspellpotentia.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("summon bloodmagic:corrupted_chicken", player, world, false, true);
 	Commands.call("summon bloodmagic:corrupted_sheep", player, world, false, true);
 	Commands.call("summon bloodmagic:corrupted_spider", player, world, false, true);
@@ -247,6 +298,9 @@ var masterspellalienis = VanillaFactory.createItem("master_spell_alienis");
 masterspellalienis.maxStackSize = 1;
 masterspellalienis.glowing = true;
 masterspellalienis.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("pillar-spawn master_spell_structure_alienis", player, world, false, true);
 	return "Pass";
 };
@@ -257,6 +311,9 @@ var warrenblindfold = VanillaFactory.createItem("warren_blindfold");
 warrenblindfold.maxStackSize = 64;
 warrenblindfold.beaconPayment = false;
 warrenblindfold.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 
 	if(player.getDimension() != 684) {
         player.sendChat("You gotta be in the Limbo");
@@ -278,6 +335,9 @@ var masterspellvictus = VanillaFactory.createItem("master_spell_victus");
 masterspellvictus.maxStackSize = 1;
 masterspellvictus.glowing = true;
 masterspellvictus.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("summon Item ~ ~10 ~ {Item:{id:\"contenttweaker:lively_twilight_gem\",Count:1b}}", player, world, false, true);
 	return "Pass";
 };
@@ -287,6 +347,9 @@ var masterspellordo = VanillaFactory.createItem("master_spell_ordo");
 masterspellordo.maxStackSize = 1;
 masterspellordo.glowing = true;
 masterspellordo.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	player.sendChat("May be useful in the Underworld, Outer Sky, for the Lost Possessed Stone");
 	Commands.call("fill ~-5 ~-5 ~-5 ~5 ~5 ~5 draconicevolution:draconium_ore 2 replace minecraft:end_stone", player, world, false, true);
 	Commands.call("fill ~-5 ~-5 ~-5 ~5 ~5 ~5 appliedenergistics2:sky_stone_block 0 replace minecraft:stone", player, world, false, true);
@@ -301,6 +364,9 @@ var masterspelldraco = VanillaFactory.createItem("master_spell_draco");
 masterspelldraco.maxStackSize = 1;
 masterspelldraco.glowing = true;
 masterspelldraco.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("/summon abyssalcraft:dragonminion ~ ~5 ~ {HandItems:[{Count:1,id:\"contenttweaker:lost_soul_of_entropy\"},{}],HandDropChances:[1.0f,0.0f],CustomName:\"Lost Chaotic Soul\",ForgeCaps:{\"twilightforest:cap_shield\":{tempshields:50,permshields:50}},Attributes:[{Name:generic.maxHealth, Base:5000.0},{Name:generic.attackDamage, Base:100.0}],Health:5000f}", player, world, false, true);
 	return "Pass";
 };
@@ -310,6 +376,9 @@ var masterspellhumanus = VanillaFactory.createItem("master_spell_humanus");
 masterspellhumanus.maxStackSize = 1;
 masterspellhumanus.glowing = true;
 masterspellhumanus.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("/summon villager ~ ~3 ~ {CustomName:\"Cool Banker\",Offers:{Recipes:[{buy:{id:\"aoa3:copper_coin\",Count:2},sell:{id:\"aoa3:silver_coin\",Count:1},rewardExp:0b,maxUses:9999999}]},Profession:2,Career:1,CareerLevel:3}", player, world, false, true);
 	Commands.call("/summon villager ~ ~3 ~ {CustomName:\"Cool Banker\",Offers:{Recipes:[{buy:{id:\"aoa3:silver_coin\",Count:2},sell:{id:\"aoa3:gold_coin\",Count:1},rewardExp:0b,maxUses:9999999}]},Profession:2,Career:1,CareerLevel:3}", player, world, false, true);
 	return "Pass";
@@ -320,6 +389,9 @@ var masterspellsensus = VanillaFactory.createItem("master_spell_sensus");
 masterspellsensus.maxStackSize = 1;
 masterspellsensus.glowing = true;
 masterspellsensus.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("/effect @p minecraft:night_vision 999999 1", player, world, false, true);
 	return "Pass";
 };
@@ -329,6 +401,9 @@ var masterspellignis = VanillaFactory.createItem("master_spell_ignis");
 masterspellignis.maxStackSize = 1;
 masterspellignis.glowing = true;
 masterspellignis.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("fill ~-5 ~-5 ~-5 ~5 ~5 ~5 minecraft:lava 0 replace minecraft:water", player, world, false, true);
 	return "Pass";
 };
@@ -338,6 +413,9 @@ var masterspellmythus = VanillaFactory.createItem("master_spell_mythus");
 masterspellmythus.maxStackSize = 1;
 masterspellmythus.glowing = true;
 masterspellmythus.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	player.sendChat("Can be killed, just hit it hard enough!");
 	Commands.call("/summon iceandfire:deathworm ~ ~ ~ {Scale:10f,WormAge:10, HandItems:[{Count:1,id:\"tardis:gallifreyan_stone\"},{}],HandDropChances:[1.0f,0.0f],CustomName:\"Great Sandworm\",ForgeCaps:{\"twilightforest:cap_shield\":{tempshields:20,permshields:20}}}", player, world, false, true);
 	return "Pass";
@@ -349,6 +427,9 @@ var masterspellaversio = VanillaFactory.createItem("master_spell_aversio");
 masterspellaversio.maxStackSize = 1;
 masterspellaversio.glowing = true;
 masterspellaversio.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("/summon minecraft:zombie ~ ~ ~ {HandItems:[{Count:1,id:\"aoa3:baron_greatblade\"},{}],HandDropChances:[1.0f,0.0f],CustomName:\"Fallen Berserker\",Attributes:[{Name:generic.maxHealth, Base:5000.0},{Name:generic.attackDamage, Base:100.0}],Health:5000f}", player, world, false, true);
 	return "Pass";
 };
@@ -360,6 +441,9 @@ var masterspellinfernum = VanillaFactory.createItem("master_spell_infernum");
 masterspellinfernum.maxStackSize = 1;
 masterspellinfernum.glowing = true;
 masterspellinfernum.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("summon Item ~ ~10 ~ {Item:{id:\"contenttweaker:cursed_dragon_egg\",Count:1b}}", player, world, false, true);
 	return "Pass";
 };
@@ -370,6 +454,9 @@ var masterspellsonus = VanillaFactory.createItem("master_spell_sonus");
 masterspellsonus.maxStackSize = 1;
 masterspellsonus.glowing = true;
 masterspellsonus.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("/summon mowziesmobs:naga ~ ~3 ~ {HandItems:[{Count:1,id:\"iceandfire:weezer_blue_album\"},{}],HandDropChances:[1.0f,0.0f],CustomName:\"Sound Engineer Wyvern\",ForgeCaps:{\"twilightforest:cap_shield\":{tempshields:10,permshields:10}},Attributes:[{Name:generic.maxHealth, Base:5000.0},{Name:generic.attackDamage, Base:100.0}],Health:5000f}", player, world, false, true);
 	return "Pass";
 };
@@ -380,6 +467,9 @@ var masterspellcognitio = VanillaFactory.createItem("master_spell_cognitio");
 masterspellcognitio.maxStackSize = 1;
 masterspellcognitio.glowing = true;
 masterspellcognitio.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("/summon thaumcraft:giantbrainyzombie ~ ~3 ~ {HandItems:[{Count:10,id:\"contenttweaker:salt_of_knowledge\"},{}],HandDropChances:[1.0f,0.0f],CustomName:\"Giant Brainy Zombie\",ForgeCaps:{\"twilightforest:cap_shield\":{tempshields:40,permshields:40}},Attributes:[{Name:generic.maxHealth, Base:2000.0},{Name:generic.attackDamage, Base:100.0}],Health:2000f}", player, world, false, true);
 	return "Pass";
 };
@@ -390,6 +480,9 @@ var masterspellimperium = VanillaFactory.createItem("master_spell_imperium");
 masterspellimperium.maxStackSize = 1;
 masterspellimperium.glowing = true;
 masterspellimperium.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	val entity = <entity:erebus:erebus.animated_block>.createEntity(world);
     entity.position = Position3f.create(player.x, player.y + 5, player.z);
     (entity.native as EntityAnimatedBlock).setBlock(<item:contenttweaker:stone_of_constraint>.asBlock(), 0);
@@ -403,6 +496,9 @@ var masterspelltenebrae = VanillaFactory.createItem("master_spell_tenebrae");
 masterspelltenebrae.maxStackSize = 1;
 masterspelltenebrae.glowing = true;
 masterspelltenebrae.itemRightClick = function(stack, world, player, hand) {
+	if(world.remote) {
+        return "FAIL";
+    }
 	Commands.call("/summon abyssalcraft:shadowmonster ~5 ~3 ~5 {HandItems:[{Count:10,id:\"contenttweaker:dark_capacitor_shard\"},{}],HandDropChances:[1.0f,0.0f],CustomName:\"Tnebrous Shadow\",ForgeCaps:{\"twilightforest:cap_shield\":{tempshields:40,permshields:40}},Attributes:[{Name:generic.maxHealth, Base:1000.0},{Name:generic.attackDamage, Base:50.0}],Health:1000f}", player, world, false, true);
 	Commands.call("/summon abyssalcraft:shadowmonster ~-5 ~3 ~5 {HandItems:[{Count:10,id:\"contenttweaker:dark_capacitor_shard\"},{}],HandDropChances:[1.0f,0.0f],CustomName:\"Tnebrous Shadow\",ForgeCaps:{\"twilightforest:cap_shield\":{tempshields:40,permshields:40}},Attributes:[{Name:generic.maxHealth, Base:1000.0},{Name:generic.attackDamage, Base:50.0}],Health:1000f}", player, world, false, true);
 	Commands.call("/summon abyssalcraft:shadowmonster ~5 ~3 ~-5 {HandItems:[{Count:10,id:\"contenttweaker:dark_capacitor_shard\"},{}],HandDropChances:[1.0f,0.0f],CustomName:\"Tnebrous Shadow\",ForgeCaps:{\"twilightforest:cap_shield\":{tempshields:40,permshields:40}},Attributes:[{Name:generic.maxHealth, Base:1000.0},{Name:generic.attackDamage, Base:50.0}],Health:1000f}", player, world, false, true);


### PR DESCRIPTION
Master spells and other items added via CT in MasterSpells.zs were not checking sides correctly when executing item right click actions, leading to unintended side effects (such as double messages in chat, ghost entities on client, ...).
This PR fixes this by adding a side check before any logic is executed, therefore only ever executing any logic on one side only (the server).