### PR TITLE
Fix spelling: Intergrated -> Integrated

### DIFF
--- a/config/betterquesting/DefaultQuests/Quests/4/90306.json
+++ b/config/betterquesting/DefaultQuests/Quests/4/90306.json
@@ -11,7 +11,7 @@
         "id:8": "botania:cosmetic",
         "tag:10": {}
       },
-      "name:8": "Intergrated Circuitry"
+      "name:8": "Integrated Circuitry"
     }
   },
   "questID:3": 90306,


### PR DESCRIPTION
Fixed typo in quest name
Quest 90306
"Intergrated Circuitry" -> "Integrated Circuitry"