### PR TITLE
Make zinc essence craft into Tech Reborn zinc

### DIFF
--- a/scripts/MysticalFixes.zs
+++ b/scripts/MysticalFixes.zs
@@ -24,6 +24,13 @@ recipes.addShaped(<techreborn:ingot:14>*2,
 [<mysticalagriculture:titanium_essence>, null, <mysticalagriculture:titanium_essence>],
 [<mysticalagriculture:titanium_essence>, <mysticalagriculture:titanium_essence>, <mysticalagriculture:titanium_essence>]]);
 
+recipes.removeByRecipeName("mysticalagriculture:ingotzinc");
+
+recipes.addShaped(<techreborn:ingot:18>*4,
+[[<mysticalagriculture:zinc_essence>, <mysticalagriculture:zinc_essence>, <mysticalagriculture:zinc_essence>],
+[<mysticalagriculture:zinc_essence>, null, <mysticalagriculture:zinc_essence>],
+[<mysticalagriculture:zinc_essence>, <mysticalagriculture:zinc_essence>, <mysticalagriculture:zinc_essence>]]);
+
 recipes.removeShaped(<avaritia:resource:3>,
 [[<mysticalagradditions:neutronium_essence>, <mysticalagradditions:neutronium_essence>, <mysticalagradditions:neutronium_essence>],
 [<mysticalagradditions:neutronium_essence>, <mysticalagradditions:neutronium_essence>, <mysticalagradditions:neutronium_essence>],


### PR DESCRIPTION
Default Mystical agriculture recipe outputs Railcraft zinc which is near useless.

This change has been tested ingame. The following is the JEI uses page for zinc essence
<img width="2560" height="1440" alt="2025-12-12_00 44 19" src="https://github.com/user-attachments/assets/2cdc6723-cc95-4440-9638-b5d4fbbcb74f" />