### PR TITLE
ptah obsidian world textures and disable Botania clientspam

### DIFF
--- a/config/advRocketry/planetDefs.xml
+++ b/config/advRocketry/planetDefs.xml
@@ -65,7 +65,7 @@
             <rotationalPeriod>20000</rotationalPeriod>
             <biomeIds>advancedrocketry:hotdryrock,nuclearcraft:nuclear_wasteland</biomeIds>
 		</planet>
-		<planet name="Ptah" DIMID="149" customIcon="Venusian">
+		<planet name="Ptah" DIMID="149" customIcon="obsidian">
             <fogColor>0.4,0.3,0.0</fogColor>
             <skyColor>0.4,0.3,0.0</skyColor>
             <atmosphereDensity>20</atmosphereDensity>

--- a/config/botania.cfg
+++ b/config/botania.cfg
@@ -209,7 +209,7 @@ general {
     B:vanillaParticleConfig.enabled=true
 
     # Set this to false to disable checking and alerting when new Botania CEu versions come out. (keywords for noobs: update notification message)
-    B:versionChecking.enabled=true
+    B:versionChecking.enabled=false
 
     # Set this to true to use a static wand beam that shows every single position of the burst, similar to the way it used to work on old Botania versions. Warning: Disabled by default because it may be laggy.
     B:wandBeam.static=false


### PR DESCRIPTION
* AR 2.2.14 adds obsidian planeticon and planetLEO textures. lorewise cooler to arrive on ptah looking like this from station or rocket descent.
<img width="1329" height="722" alt="image" src="https://github.com/user-attachments/assets/644908e7-0174-4b2e-a112-20218ba0776c" />

* Remove or repair methanol in planetdefs
```
[10:21:11] [Server thread/INFO] [advancedrocketry]: Advanced Planet Config file Found!  Loading from file.
[10:21:12] [Server thread/WARN] [advancedrocketry]: "fluid_methanol" is not a valid fluid
```

* AR config:
Removed dead gas mining group,
and 2 errormessages from MBC load:
```
blank line in harvestable gasses.
and unusued methane  failing to register for "random generated gasgiants", so irrelevant for runtime, just noise in log.
```

* Botania added (repaired an old) version check when joining world. 